### PR TITLE
[Improvement] Memory Leak fix for Singular job calls 

### DIFF
--- a/src/initialization/jobsManager.ts
+++ b/src/initialization/jobsManager.ts
@@ -1,7 +1,7 @@
 import { JobConsumer } from "@jobConsumer/jobConsumer";
 import { JobDTO, jobStatus } from "@typesDef/models/job";
 import currentRunsManager from "@utils/CurrentRunsManager";
-import logger, { JobLogger } from "@utils/loggers";
+import logger, { deleteJobLogger, JobLogger } from "@utils/loggers";
 import schedulerManager from "schedule-manager";
 const { ScheduleJobEventBus, ScheduleJobLogEventBus, ScheduleJobManager } =
   schedulerManager;
@@ -88,8 +88,10 @@ export const registerSingularJobStartAndEndActions = (job: JobDTO) => {
   }
   currentRunsManager.startJob(job);
   ScheduleJobEventBus.once(`completed:${eventTargetId}`, (endedJob: JobDTO) => {
+    logger.trace(`Singular job completed ${job.getUniqueSingularId()!}`);
     currentRunsManager.endJob(endedJob);
     delete currentRunsManager.initialized[eventTargetId];
+    deleteJobLogger(job.getUniqueSingularId()!);
   });
   currentRunsManager.initialized[eventTargetId] = true;
 };

--- a/src/jobConsumer/jobConsumer.ts
+++ b/src/jobConsumer/jobConsumer.ts
@@ -72,11 +72,18 @@ export class JobConsumer extends Consumer {
     }
   }
 
-  run(job: JobDTO, jobLog: JobLogDTO) {
-    return super.run(job, jobLog);
+  jobInputParse(job: JobDTO, jobLog: JobLogDTO) {
+    if (job.param && typeof job.param === "string") {
+      job.param = JSON.parse(job.param);
+    }
+    return {
+      job,
+      jobLog,
+    };
   }
 
-  async preRun(job: JobDTO, jobLog: JobLogDTO) {
+  async preRun(j: JobDTO, jl: JobLogDTO) {
+    const { job, jobLog } = this.jobInputParse(j, jl);
     this.job = job;
     this.jobLog = jobLog;
     await this.injectProxies();

--- a/src/utils/loggers.ts
+++ b/src/utils/loggers.ts
@@ -64,6 +64,31 @@ const JobLogger = (id: string, name: string) => {
   loggers[id] = pino(jobTransport);
   return loggers[id];
 };
+const deleteJobLogger = (id: string) => {
+  try {
+    const targetLogger = loggers[id];
+    if (targetLogger) {
+      const symbols = Object.getOwnPropertySymbols(targetLogger);
+      const targetSymbol = symbols.find(
+        (e) => e.toString() === "Symbol(pino.stream)",
+      )!;
+      // @ts-ignore
+      const targetThreadStream: any = targetLogger[targetSymbol];
+      const KimplSymbol = Object.getOwnPropertySymbols(targetThreadStream).find(
+        (e) => e.toString() === "Symbol(kImpl)",
+      )!;
+      targetThreadStream[KimplSymbol].dataBuf = null;
+      delete targetThreadStream[KimplSymbol].data;
+      delete targetThreadStream?.worker?._events;
+      targetThreadStream?.removeAllListeners();
+      targetThreadStream?.end();
+      generalLogger.trace(`logger for ${id} deleted`);
+      delete loggers[id];
+    }
+  } catch (err) {
+    generalLogger.error(err);
+  }
+};
 
 const generalTransport = pino.transport({
   targets: <TransportTargetOptions[]>[
@@ -75,12 +100,20 @@ const generalTransport = pino.transport({
     config.get("server.logToConsole") && {
       target: "pino-pretty",
       level: "error",
-      options: { destination: 1, colorize: true, ignore: "pid,hostname" },
+      options: {
+        destination: 1,
+        colorize: true,
+        ignore: "pid,hostname",
+      },
     },
     config.get("server.logToConsole") && {
       target: "pino-pretty",
       level: "info",
-      options: { destination: 1, colorize: true, ignore: "pid,hostname" },
+      options: {
+        destination: 1,
+        colorize: true,
+        ignore: "pid,hostname",
+      },
     },
     {
       target: "pino/file",
@@ -98,4 +131,4 @@ generalTransport.on("error", (err: any) => {
 const generalLogger = pino(generalTransport);
 
 export default generalLogger;
-export { JobLogger };
+export { deleteJobLogger, JobLogger, loggers };


### PR DESCRIPTION
**Improvements:**
- fixing memory leak related to pino loggers, we now delete loggers used in singular job calls
- adding small updates to better handle params on jobs

**Notes:**
- The pinoJs logger instance was hard to get rid of after the singular job ended due to it using a separate thread to log messages. 
- a new known issue is introduced by this update, that only occurs on very fast and repeated job calls (sub 5 sec call) where separate thread loggers would initiate a log after the job ended, all due to the async nature of the logging. but this is far from an urgent case atm. 