### PR TITLE
[Feature] enabling custom inputs for single job runs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -614,7 +614,7 @@
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
-    "schedule-manager": ["schedule-manager@github:moda20/node-schedule-manager#e13259e", { "dependencies": { "app-root-path": "^3.0.0", "dotenv": "^16.5.0", "ip": "^1.1.5", "moment": "^2.29.1", "mysql": "^2.18.1", "mysql2": "^3.14.1", "node-cron": "^3.0.0" } }, "moda20-node-schedule-manager-e13259e"],
+    "schedule-manager": ["schedule-manager@github:moda20/node-schedule-manager#5f59178", { "dependencies": { "app-root-path": "^3.0.0", "dotenv": "^16.5.0", "ip": "^1.1.5", "moment": "^2.29.1", "mysql": "^2.18.1", "mysql2": "^3.14.1", "node-cron": "^3.0.0" } }, "moda20-node-schedule-manager-5f59178"],
 
     "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
 

--- a/src/api/jobs/jobs.controller.ts
+++ b/src/api/jobs/jobs.controller.ts
@@ -61,10 +61,10 @@ export const JobsController = createElysia({ prefix: "/jobs" })
         action: t.String(),
         config: t.Optional(
           t.Object({
-            name: t.String(),
+            name: t.Optional(t.String()),
             param: t.Optional(Nullable(t.String())),
-            consumer: t.String(),
-            cronSetting: t.String(),
+            consumer: t.Optional(t.String()),
+            cronSetting: t.Optional(t.String()),
           }),
         ),
       }),

--- a/src/jobConsumer/jobConsumer.ts
+++ b/src/jobConsumer/jobConsumer.ts
@@ -75,6 +75,12 @@ export class JobConsumer extends Consumer {
   jobInputParse(job: JobDTO, jobLog: JobLogDTO) {
     if (job.param && typeof job.param === "string") {
       job.param = JSON.parse(job.param);
+      if (job.extraParams) {
+        job.param = {
+          ...job.param,
+          ...job.extraParams,
+        };
+      }
     }
     return {
       job,

--- a/src/repositories/jobs.ts
+++ b/src/repositories/jobs.ts
@@ -139,17 +139,23 @@ export const updateJobConfig = async (
 ) => {
   const { job } = await ScheduleJobManager.getJobById(Number(id));
   if (job) {
+    const cronSettingChanged = newConfig?.cronSetting !== job?.getCronSetting();
     job.setCronSetting(newConfig?.cronSetting ?? job?.getCronSetting());
     job.setName(newConfig?.name ?? job?.getName());
     job.setParam(newConfig?.param ?? job?.getParam());
     job.setConsumer(newConfig?.consumer ?? job?.getConsumer());
-    return await ScheduleJobManager.updateJob(Number(id), job);
+    return await ScheduleJobManager.updateJob(Number(id), job).then(() => {
+      if (cronSettingChanged) {
+        refreshJobRegistration(Number(id));
+      }
+      return { success: true };
+    });
   }
 };
 
 export const refreshJobRegistration = async (id: number | number[]) => {
   const targetJobIds = Array.isArray(id) ? id : [id];
-  await Promise.all(
+  return await Promise.all(
     targetJobIds.map((id) => {
       return Promise.resolve(ScheduleJobManager.stopJobById(id))
         .then((jobStopped) => {
@@ -242,9 +248,11 @@ export const jobActionExecution = async (
         });
       });
     }
-    case jobActions.EXECUTE: {
+    case jobActions.EXECUTE:
+    case jobActions.EXECUTE_WITH_PARAMS: {
       return ScheduleJobManager.jobRegistration(id, {
         singular: true,
+        extraParams: config?.param && JSON.parse(config.param),
       }).then((registrationData) => {
         if (!registrationData.success) {
           throw new Error("Error when registering job", {

--- a/src/types/models/job.ts
+++ b/src/types/models/job.ts
@@ -244,6 +244,7 @@ export enum jobActions {
   EXECUTE = "EXECUTE",
   UPDATE = "UPDATE",
   REFRESH = "REFRESH",
+  EXECUTE_WITH_PARAMS = "EXECUTE_WITH_PARAMS",
 }
 
 export enum jobStatus {


### PR DESCRIPTION
**Features:**
- updating execution endpoint to take extra parameters for custom executions
- Injecting the new attribute `extraParams` into the job's `param` before running the job

**Notes:**
- Updated the `node-schedule-manager` to the latest version.