### PR TITLE
[Bug Fix] fixing content type issue when downloading files based on path name

### DIFF
--- a/src/api/files/outputFiles.controller.ts
+++ b/src/api/files/outputFiles.controller.ts
@@ -16,8 +16,10 @@ import { file } from "bun";
 import qs from "qs";
 
 export const outputFilesController = createElysia({ prefix: "/files" })
-  .onBeforeHandle(({ set }) => {
-    set.headers["content-type"] = "application/json; charset=utf-8";
+  .onBeforeHandle(({ set, path }) => {
+    if (!path?.toLowerCase().includes("download")) {
+      set.headers["content-type"] = "application/json; charset=utf-8";
+    }
   })
   .onTransform((ctx) => {
     // @ts-ignore

--- a/src/api/system/system.controller.ts
+++ b/src/api/system/system.controller.ts
@@ -9,8 +9,10 @@ import { file } from "bun";
 import qs from "qs";
 
 export const systemController = createElysia({ prefix: "/system" })
-  .onBeforeHandle(({ set }) => {
-    set.headers["content-type"] = "application/json; charset=utf-8";
+  .onBeforeHandle(({ set, path }) => {
+    if (!path?.toLowerCase().includes("download")) {
+      set.headers["content-type"] = "application/json; charset=utf-8";
+    }
   })
   .onTransform((ctx) => {
     // @ts-ignore


### PR DESCRIPTION
**Notes:**
- setting the `application/json`response type only for none-file-downloaders routes, this is based on the path name for now until we can do it differently