### PR TITLE
[Bug Fix] Fixing the datetype for the Advanced filtering api to handle a single date as the current date

### DIFF
--- a/src/utils/jobUtils.ts
+++ b/src/utils/jobUtils.ts
@@ -11,6 +11,7 @@ import cronParser from "cron-parser";
 import { readdirSync, statSync } from "fs-extra";
 import path, { join, parse } from "path";
 import { IScheduleJobLog } from "schedule-manager";
+import dayjs from "@utils/dayJs";
 export const Nullable = <T extends TSchema>(T: T) => {
   // type Nullable<T> = T | null
   return t.Union([T, t.Null()]);
@@ -260,13 +261,20 @@ export const parseTypedValueToPrismaValue = (
       };
     case "regex":
       return typedValue;
-    case "between":
+    case "between": {
+      const upperValue = isADateValue
+        ? typedValue.value2
+          ? new Date(typedValue.value2)
+          : dayjs(typedValue.value1).add(1, "day").toDate()
+        : typedValue.value2;
       return {
         [attribute]: {
           gte: isADateValue ? new Date(typedValue.value1) : typedValue.value1,
-          lte: isADateValue ? new Date(typedValue.value2) : typedValue.value2,
+          lte: upperValue,
         },
       };
+    }
+
     default:
       return null;
   }


### PR DESCRIPTION
**Bug Fixes :**
- Fixing the parsing error resulting from passing a single date and having an invalid date passed to prisma. When passing a single date a 24h period will be added to it and used as the upper value of the search clause. 