### PR TITLE
[FEATURE] Adding job export and import to JSON endpoints

### DIFF
--- a/src/api/jobs/jobs.controller.ts
+++ b/src/api/jobs/jobs.controller.ts
@@ -2,6 +2,7 @@ import { t } from "elysia";
 
 import config from "@config/config";
 import {
+  exportJobsToJSON,
   getAllJobs,
   getAvailableConsumers,
   getFilteredJobs,
@@ -10,12 +11,19 @@ import {
   getJobStats,
   getLokiLogs,
   getRunningJobs,
+  importJobsFromJSON,
   isJobRunning,
   jobActionExecution,
   queueJobExecution,
 } from "@repositories/jobs";
-import { createElysia, FilterableType } from "@utils/createElysia";
+import {
+  BatchInputJob,
+  createElysia,
+  FilterableType,
+  JobsAdvancedFilters,
+} from "@utils/createElysia";
 import currentRunsManager from "@utils/CurrentRunsManager";
+import dayJs from "@utils/dayJs";
 import { Nullable, toJSON } from "@utils/jobUtils";
 import qs from "qs";
 
@@ -57,18 +65,7 @@ export const JobsController = createElysia({ prefix: "/jobs" })
       return getFilteredJobs(body);
     },
     {
-      body: t.Object({
-        name: t.Optional(FilterableType),
-        consumer: t.Optional(FilterableType),
-        cronSetting: t.Optional(FilterableType),
-        averageTime: t.Optional(FilterableType),
-        latestRun: t.Optional(FilterableType),
-        status: t.Optional(t.Array(t.String())),
-        isRunning: t.Optional(t.Boolean()),
-        sorting: t.Optional(
-          t.Array(t.Object({ id: t.String(), desc: t.Boolean() })),
-        ),
-      }),
+      body: JobsAdvancedFilters,
     },
   )
   .post(
@@ -177,5 +174,30 @@ export const JobsController = createElysia({ prefix: "/jobs" })
         limit: t.Optional(t.Union([t.Number(), t.String()])),
         offset: t.Optional(t.Union([t.Number(), t.String()])),
       }),
+    },
+  )
+  .post(
+    "/exportJobsToJSON",
+    ({ body, set }) => {
+      set.headers["content-disposition"] =
+        `attachment; filename="${dayJs().format("YYYY_MM_DD_HH_mm_ss")}_exported_jobs.json`;
+      return exportJobsToJSON(body);
+    },
+    {
+      body: t.Optional(
+        t.Object({
+          jobIds: t.Optional(t.Array(t.Number())),
+          advancedFilters: t.Optional(JobsAdvancedFilters),
+        }),
+      ),
+    },
+  )
+  .post(
+    "/importJobsFromJSON",
+    ({ body }) => {
+      return importJobsFromJSON(body);
+    },
+    {
+      body: t.Array(BatchInputJob),
     },
   );

--- a/src/repositories/jobs.ts
+++ b/src/repositories/jobs.ts
@@ -347,6 +347,72 @@ export const jobActionExecution = async (
   }
 };
 
+export const exportJobsToJSON = async ({
+  jobIds,
+  advancedFilters,
+}: {
+  jobIds?: number[];
+  advancedFilters?: advancedFilters;
+}) => {
+  let jobsList: JobDTOClass[] = [];
+  if (advancedFilters) {
+    jobsList = await getFilteredJobs(advancedFilters);
+  } else {
+    jobsList = await getAllJobs({
+      limit: 999999,
+      offset: 0,
+      jobIds: jobIds,
+      status: ["STARTED", "STOPPED"],
+      name: "",
+      sort: [],
+    });
+  }
+  return jobsList.map((job) => {
+    return {
+      consumer: job.getConsumer(),
+      job_name: job.getName(),
+      job_param: job.getParam(),
+      job_cron_setting: job.getCronSetting(),
+      status: job.getStats(),
+    };
+  });
+};
+
+export const importJobsFromJSON = async (jobs: any[] = []) => {
+  const results = await Promise.allSettled(
+    jobs.map((job) => {
+      return ScheduleJobManager.newJob(
+        job.job_name,
+        job.job_cron_setting,
+        job.job_param,
+        job.consumer,
+        true,
+        job.status ?? jobStatus.STOPPED,
+      ).then((d) => {
+        if (d.success && d.job) {
+          registerJobStartAndEndActions(d.job);
+          return `Job ${d.job.name} created successfully`;
+        }
+        throw new Error("Error when creating Job", {
+          cause: {
+            errorOutput: d,
+            job: job,
+          },
+        });
+      });
+    }),
+  );
+  return results.map((res) => {
+    if (res.status === "fulfilled") {
+      return res.value;
+    } else {
+      return {
+        error: res.reason.cause.errorOutput,
+        inputJob: res.reason.cause.job,
+      };
+    }
+  });
+};
 export const queueJobExecution = async (
   execConfig: queuedJobsExecutionConfig,
 ) => {

--- a/src/utils/createElysia.ts
+++ b/src/utils/createElysia.ts
@@ -17,3 +17,27 @@ export const FilterableType = t.Optional(
     value2: t.Optional(t.Union([t.String(), t.Number()])),
   }),
 );
+
+export const JobsAdvancedFilters = t.Object({
+  name: t.Optional(FilterableType),
+  consumer: t.Optional(FilterableType),
+  cronSetting: t.Optional(FilterableType),
+  averageTime: t.Optional(FilterableType),
+  latestRun: t.Optional(FilterableType),
+  status: t.Optional(t.Array(t.String())),
+  isRunning: t.Optional(t.Boolean()),
+  sorting: t.Optional(t.Array(t.Object({ id: t.String(), desc: t.Boolean() }))),
+});
+
+export const BatchInputJob = t.Object({
+  job_name: t.String(),
+  job_param: t.String(),
+  job_cron_setting: t.String(),
+  consumer: t.String(),
+  status: t.Optional(
+    t.Union([
+      t.Enum({ STOPPED: "STOPPED", STARTED: "STARTED" }),
+      t.Array(t.Enum({ STOPPED: "STOPPED", STARTED: "STARTED" })),
+    ]),
+  ),
+});


### PR DESCRIPTION
**Features :**
- Adding endpoints to import and export Jobs to JSON

**Notes :**
- The input JSON is ONLY validated by the endpoint Typebox validation of Elysja 
- The import endpoint will return 200 even if some jobs have issues created, it will however return the error message and the  input job