### PR TITLE
[FEATURE] Adding lobal events Logging + api/ws querying

### DIFF
--- a/src/api/jobs/jobs.controller.ts
+++ b/src/api/jobs/jobs.controller.ts
@@ -139,7 +139,7 @@ export const JobsController = createElysia({ prefix: "/jobs" })
   .get(
     "/jobLogs/loki",
     async ({ query }) => {
-      const { start, end, query: queryString } = query;
+      const { start, end, query: queryString, mergeStreams } = query;
       if (!config.get("grafana.lokiUrl")) {
         throw new Error("Loki connection is not configured", {
           cause: 400,
@@ -150,13 +150,28 @@ export const JobsController = createElysia({ prefix: "/jobs" })
         Number(start),
         Number(end),
       );
-      return data;
+      if (mergeStreams) {
+        const flattenedStreams = data.data.result.flatMap((stream: any) =>
+          stream.values.map(([ts, line]: [string, string]) => [
+            Number(ts),
+            line,
+            stream.stream,
+          ]),
+        );
+
+        // sort by timestamp
+        flattenedStreams.sort((a, b) => a[0] - b[0]);
+        return flattenedStreams;
+      } else {
+        return data;
+      }
     },
     {
       query: t.Object({
         start: t.Optional(t.Union([t.Number(), t.String()])),
         end: t.Optional(t.Union([t.Number(), t.String()])),
         query: t.String(),
+        mergeStreams: t.Optional(t.Boolean()),
       }),
     },
   )

--- a/src/api/websocket/mainSocket.communication.ts
+++ b/src/api/websocket/mainSocket.communication.ts
@@ -3,6 +3,8 @@ import { ElysiaWS } from "elysia/dist/ws";
 import { JobNotificationTopics } from "@typesDef/api/websocket";
 import currentRunsManager from "@utils/CurrentRunsManager";
 
+import mainSocketService from "./mainSocket.service";
+
 export default function handleSocketMessage(message: any, ws: ElysiaWS<any>) {
   switch (message.id) {
     case JobNotificationTopics.Status: {
@@ -12,6 +14,23 @@ export default function handleSocketMessage(message: any, ws: ElysiaWS<any>) {
           runningJobCount: currentRunsManager.getRunningJobCount(),
         }),
       });
+      break;
+    }
+    case JobNotificationTopics.SubscribeToTopic: {
+      console.log(message);
+      if (message.message) {
+        const userId = ws.data.headers["x-user-id"];
+        mainSocketService.subscribeToTopic(userId, [message.message]);
+      }
+      break;
+    }
+    case JobNotificationTopics.UnsubscribeFromTopic: {
+      console.log(message);
+      if (message.message) {
+        const userId = ws.data.headers["x-user-id"];
+        mainSocketService.unsubscribeFromTopics(userId, [message.message]);
+      }
+      break;
     }
   }
 }

--- a/src/api/websocket/mainSocket.communication.ts
+++ b/src/api/websocket/mainSocket.communication.ts
@@ -2,6 +2,7 @@ import { ElysiaWS } from "elysia/dist/ws";
 
 import { JobNotificationTopics } from "@typesDef/api/websocket";
 import currentRunsManager from "@utils/CurrentRunsManager";
+import { forceToArray } from "@utils/socketUtils";
 
 import mainSocketService from "./mainSocket.service";
 
@@ -17,18 +18,22 @@ export default function handleSocketMessage(message: any, ws: ElysiaWS<any>) {
       break;
     }
     case JobNotificationTopics.SubscribeToTopic: {
-      console.log(message);
       if (message.message) {
         const userId = ws.data.headers["x-user-id"];
-        mainSocketService.subscribeToTopic(userId, [message.message]);
+        mainSocketService.subscribeToTopic(
+          userId,
+          forceToArray(message.message),
+        );
       }
       break;
     }
     case JobNotificationTopics.UnsubscribeFromTopic: {
-      console.log(message);
       if (message.message) {
         const userId = ws.data.headers["x-user-id"];
-        mainSocketService.unsubscribeFromTopics(userId, [message.message]);
+        mainSocketService.unsubscribeFromTopics(
+          userId,
+          forceToArray(message.message),
+        );
       }
       break;
     }

--- a/src/api/websocket/mainSocket.service.ts
+++ b/src/api/websocket/mainSocket.service.ts
@@ -63,7 +63,6 @@ export default {
     );
   },
   subscribeToTopic(userId: string, topics: string[]) {
-    console.log(MiscNotificationTopicsList, topics);
     if (topics.every((e) => MiscNotificationTopicsList.includes(e))) {
       this.topicsSubscriptions[userId] = Array.from(
         new Set([...(this.topicsSubscriptions[userId] ?? []), ...topics]),

--- a/src/api/websocket/mainSocket.service.ts
+++ b/src/api/websocket/mainSocket.service.ts
@@ -1,18 +1,30 @@
 import { ElysiaWS } from "elysia/dist/ws";
 
-import { JobNotificationTopics } from "@typesDef/api/websocket";
+import {
+  EventLogNotification,
+  JobNotificationTopics,
+  MiscNotificationTopics,
+  MiscNotificationTopicsList,
+} from "@typesDef/api/websocket";
 import { JobDTO } from "@typesDef/models/job";
 
 export default {
   clients: {} as { [key: string]: ElysiaWS<any> },
+  topicsSubscriptions: {} as { [key: string]: string[] },
   socket: null,
   setWsClient(client: any, userId: string) {
     this.clients[userId] = client;
     this.socket = client;
   },
-  broadcastMessage(message: any) {
-    Object.values(this.clients).forEach((e) => {
-      e?.send(message);
+  broadcastMessage(message: any, topic?: string) {
+    Object.keys(this.clients).forEach((userId: string) => {
+      if (topic) {
+        if (this.topicsSubscriptions[userId]?.includes(topic)) {
+          this.clients[userId]?.send(message);
+        }
+      } else {
+        this.clients[userId]?.send(message);
+      }
     });
   },
   sendJobStartingNotification(job: JobDTO, runningJobCount: number) {
@@ -40,5 +52,27 @@ export default {
         averageTime: job.averageTime,
       }),
     });
+  },
+  sendEventLogNotification(message: EventLogNotification) {
+    this.broadcastMessage(
+      {
+        id: MiscNotificationTopics.EventLog,
+        data: JSON.stringify(message),
+      },
+      MiscNotificationTopics.EventLog,
+    );
+  },
+  subscribeToTopic(userId: string, topics: string[]) {
+    console.log(MiscNotificationTopicsList, topics);
+    if (topics.every((e) => MiscNotificationTopicsList.includes(e))) {
+      this.topicsSubscriptions[userId] = Array.from(
+        new Set([...(this.topicsSubscriptions[userId] ?? []), ...topics]),
+      );
+    }
+  },
+  unsubscribeFromTopics(userId: string, topics: string[]) {
+    this.topicsSubscriptions[userId] = this.topicsSubscriptions[userId].filter(
+      (e) => !topics.includes(e),
+    );
   },
 };

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -41,6 +41,12 @@ const config = convict({
       default: true,
       env: "LOG_TO_CONSOLE",
     },
+    logSystemEvents: {
+      doc: "Whether to log all system events, useful for debugging.",
+      format: Boolean,
+      default: true,
+      env: "LOG_SYSTEM_EVENTS",
+    },
   },
   jobs: {
     targetFolderForJobs: {

--- a/src/initialization/jobsManager.ts
+++ b/src/initialization/jobsManager.ts
@@ -1,7 +1,8 @@
 import { JobConsumer } from "@jobConsumer/jobConsumer";
+import { jobEventLog, LogEventNames } from "@typesDef/api/jobs";
 import { JobDTO, jobStatus } from "@typesDef/models/job";
 import currentRunsManager from "@utils/CurrentRunsManager";
-import logger, { JobLogger } from "@utils/loggers";
+import logger, { eventLog, JobLogger } from "@utils/loggers";
 import schedulerManager from "schedule-manager";
 const { ScheduleJobEventBus, ScheduleJobLogEventBus, ScheduleJobManager } =
   schedulerManager;
@@ -63,19 +64,19 @@ export const fullStartAJob = async (job: JobDTO) => {
 
 export const registerJobStartAndEndActions = (job: JobDTO) => {
   logger.info(`Registering jobs ${job.getName()}`);
+  const eventTargetId = job.getName();
   if (currentRunsManager.initialized[job.getName()]) {
     return; // Already initialized;
   }
-  ScheduleJobEventBus.on(
-    "scheduleJob:" + job.getName(),
-    (startedJob: JobDTO) => {
-      currentRunsManager.startJob(startedJob);
-    },
-  );
-  ScheduleJobEventBus.on("completed:" + job.getName(), (endedJob: JobDTO) => {
-    currentRunsManager.endJob(endedJob);
+  onJobStarted<JobDTO>(eventTargetId).then(({ job: startedJob, off }) => {
+    currentRunsManager.startJob(startedJob);
+    currentRunsManager.initialized[eventTargetId].startEventOff = off;
   });
-  currentRunsManager.initialized[job.getName()] = true;
+  onJobFinished<JobDTO>(eventTargetId).then(({ job: endedJob, off }) => {
+    currentRunsManager.endJob(endedJob);
+    currentRunsManager.initialized[eventTargetId].endEventOff = off;
+  });
+  currentRunsManager.initialized[job.getName()] = {};
 };
 
 export const registerSingularJobStartAndEndActions = (job: JobDTO) => {
@@ -86,24 +87,64 @@ export const registerSingularJobStartAndEndActions = (job: JobDTO) => {
   if (currentRunsManager.initialized[eventTargetId]) {
     return; // Already initialized;
   }
+  const evenLogger = eventLog(LogEventNames.JobScheduleEvent);
+  evenLogger.debug(`${jobEventLog.JOB_STARTED}: ${eventTargetId}`, {
+    eventName: `scheduleJob:${eventTargetId}`,
+  });
   currentRunsManager.startJob(job);
-  onJobFinished<JobDTO>(eventTargetId).then((endedJob: JobDTO) => {
+  onJobFinished<JobDTO>(eventTargetId, true).then(({ job: endedJob }) => {
     logger.trace(`Singular job completed ${job.getUniqueSingularId()!}`);
     currentRunsManager.endJob(endedJob);
     delete currentRunsManager.initialized[eventTargetId];
     // TODO figure out if deleting the logger manually is useful
   });
-  currentRunsManager.initialized[eventTargetId] = true;
+  currentRunsManager.initialized[eventTargetId] = {};
 };
 
-export const onJobFinished = <T>(eventTargetId: string) => {
-  return new Promise<T>((res) => {
-    ScheduleJobEventBus.once(
-      `completed:${eventTargetId}`,
-      (endedJob: JobDTO) => {
-        res(endedJob as T);
-      },
-    );
+export const onJobFinished = <T>(
+  eventTargetId: string,
+  once?: boolean,
+): Promise<{ job: T; off: () => void }> => {
+  const fullEventId = `completed:${eventTargetId}`;
+  return new Promise<{ job: T; off: () => void }>((res) => {
+    const execFunction = (endedJob: JobDTO) => {
+      const logger = eventLog(LogEventNames.JobScheduleEvent);
+      logger.debug(`${jobEventLog.JOB_ENDED}: ${eventTargetId}`, {
+        eventName: fullEventId,
+      });
+      res({
+        job: endedJob as T,
+        off: () => {
+          ScheduleJobEventBus.off(fullEventId, execFunction);
+        },
+      });
+    };
+    if (once) {
+      ScheduleJobEventBus.once(fullEventId, execFunction);
+    } else {
+      ScheduleJobEventBus.on(fullEventId, execFunction);
+    }
+  });
+};
+
+export const onJobStarted = <T>(
+  eventTargetId: string,
+): Promise<{ job: T; off: () => void }> => {
+  const fullEventId = `scheduleJob:${eventTargetId}`;
+  return new Promise<{ job: T; off: () => void }>((res) => {
+    const execFunction = (endedJob: JobDTO) => {
+      const logger = eventLog(LogEventNames.JobScheduleEvent);
+      logger.debug(`${jobEventLog.JOB_STARTED}: ${eventTargetId}`, {
+        eventName: fullEventId,
+      });
+      res({
+        job: endedJob as T,
+        off: () => {
+          ScheduleJobEventBus.off(fullEventId, execFunction);
+        },
+      });
+    };
+    ScheduleJobEventBus.on(fullEventId, execFunction);
   });
 };
 
@@ -113,19 +154,10 @@ export const unsubscribeFromAllLogs = (id: number) => {
 };
 
 export const deleteJobStartAndEndActions = (job: JobDTO) => {
-  if (currentRunsManager.initialized[job.getName()]) {
-    ScheduleJobEventBus.off(
-      "scheduleJob:" + job.getName(),
-      (startedJob: JobDTO) => {
-        currentRunsManager.startJob(startedJob);
-      },
-    );
-    ScheduleJobEventBus.off(
-      "completed:" + job.getName(),
-      (endedJob: JobDTO) => {
-        currentRunsManager.endJob(endedJob);
-      },
-    );
+  const jobInitialization = currentRunsManager.initialized[job.getName()];
+  if (jobInitialization) {
+    jobInitialization.startEventOff?.();
+    jobInitialization.endEventOff?.();
     delete currentRunsManager.initialized[job.getName()];
   }
 };

--- a/src/repositories/loggging/winstonToSocketTransport.ts
+++ b/src/repositories/loggging/winstonToSocketTransport.ts
@@ -16,7 +16,10 @@ export class WinstonToSocketTransport extends Transport {
     setImmediate(() => this.emit("logged", info));
 
     try {
-      this.logFn(info);
+      this.logFn({
+        ...info,
+        timestamp: new Date().toISOString(),
+      });
     } catch (err) {
       this.emit("error", err);
     }

--- a/src/repositories/loggging/winstonToSocketTransport.ts
+++ b/src/repositories/loggging/winstonToSocketTransport.ts
@@ -1,0 +1,26 @@
+import Transport from "winston-transport";
+
+interface CustomTransportOptions extends Transport.TransportStreamOptions {
+  logFn: (info: any) => void;
+}
+
+export class WinstonToSocketTransport extends Transport {
+  private logFn: (info: any) => void;
+
+  constructor(opts: CustomTransportOptions) {
+    super(opts);
+    this.logFn = opts.logFn;
+  }
+
+  log(info: any, callback: () => void) {
+    setImmediate(() => this.emit("logged", info));
+
+    try {
+      this.logFn(info);
+    } catch (err) {
+      this.emit("error", err);
+    }
+
+    callback();
+  }
+}

--- a/src/types/api/jobs.ts
+++ b/src/types/api/jobs.ts
@@ -42,3 +42,18 @@ export type Task<T> = () => Promise<T>;
 export interface queuedTasksExecutionConfig extends queuedJobsExecutionConfig {
   targetTasks?: Task<any>[];
 }
+
+export interface JobInitialization {
+  startEventOff?: () => void;
+  endEventOff?: () => void;
+}
+
+export enum LogEventNames {
+  "JobLogEvent" = "JobLogEvent",
+  "JobScheduleEvent" = "JobScheduleEvent",
+}
+export enum jobEventLog {
+  JOB_ENDED = "JOB_ENDED",
+  JOB_STARTED = "JOB_STARTED",
+  JOB_ERROR = "JOB_ERROR",
+}

--- a/src/types/api/websocket.ts
+++ b/src/types/api/websocket.ts
@@ -10,10 +10,24 @@ export interface JobStartedNotification extends JobNotification {
   averageTime: number;
 }
 
+export interface EventLogNotification extends JobNotification {
+  level: string;
+  eventName: string;
+}
 export enum JobNotificationTopics {
   JobStarted = "JobStarted",
   JobFinished = "JobFinished",
   JobFailed = "JobFailed",
   Status = "Status",
+  SubscribeToTopic = "SubscribeToTopic",
+  UnsubscribeFromTopic = "UnsubscribeFromTopic",
   NOOP = "NOOP",
 }
+
+export enum MiscNotificationTopics {
+  EventLog = "EventLog",
+}
+
+export const MiscNotificationTopicsList = Object.values(
+  MiscNotificationTopics,
+).map((e) => e.toString());

--- a/src/utils/CurrentRunsManager.ts
+++ b/src/utils/CurrentRunsManager.ts
@@ -1,9 +1,10 @@
 import mainSocketService from "@api/websocket/mainSocket.service";
+import { JobInitialization } from "@typesDef/api/jobs";
 import { JobDTO } from "@typesDef/models/job";
 import { JobQueue } from "@utils/queueUtils";
 export default {
   runningJobs: <Record<string, Record<string, JobDTO>>>{},
-  initialized: <Record<string, boolean>>{},
+  initialized: <Record<string, JobInitialization>>{},
   queues: Array<JobQueue>(),
   startJob(job: JobDTO) {
     if (this.runningJobs[job.getName()]) {

--- a/src/utils/loggers.ts
+++ b/src/utils/loggers.ts
@@ -1,4 +1,7 @@
+import mainSocketService from "@api/websocket/mainSocket.service";
 import config from "@config/config";
+import { WinstonToSocketTransport } from "@repositories/loggging/winstonToSocketTransport";
+import { EventLogNotification } from "@typesDef/api/websocket";
 import dayjs from "@utils/dayJs";
 import chalk from "chalk";
 import pino, { TransportTargetOptions } from "pino";
@@ -68,8 +71,8 @@ const JobLogger = (uniqueId: string, name: string) => {
         ignoredMeta: ["level"],
         metaToUseAsLabels: ["logId"],
         onConnectionError: (err) => {
-          console.log("onConnectionError", err);
-          generalLogger.error(`onConnectionError ${err}`);
+          console.log("Loki connection error", err);
+          generalLogger.error(`Loki connection error ${err}`);
         },
         handleExceptions: true,
         handleRejections: true,
@@ -122,5 +125,77 @@ generalTransport.on("error", (err: any) => {
 
 const generalLogger = pino(generalTransport);
 
+// create a logger using winston with daily rotated files
+
+const eventLog = (source: string) => {
+  if (loggers[source]) return loggers[source];
+  const options = (
+    level: string,
+  ): DailyRotateFile.DailyRotateFileTransportOptions => ({
+    filename: `./src/logs/system/event_log_${source}`,
+    auditFile: `./src/logs/system/audits/${source}-audit.json`,
+    level,
+    json: true,
+    format: regularLoggerFormat,
+    maxSize: "20m",
+    extension: ".log",
+  });
+  const transportsList = [
+    config.get("files.exportJobLogsToFiles") &&
+      new transports.DailyRotateFile(options("debug")),
+    config.get("server.logToConsole") &&
+      new transports.Console({
+        ...options("debug"),
+        format: format.combine(
+          format.timestamp(),
+          format.printf((info) => {
+            return `[${dayjs(info.timestamp as string).format("HH:mm:ss.SSS")}] ${chalk.green(info.level.padEnd(4).toUpperCase())}: ${chalk.hex("#008080")(info.message)}`;
+          }),
+        ),
+      }),
+    config.get("grafana.lokiUrl") &&
+      new LokiTransport({
+        host: config.get("grafana.lokiUrl") || "",
+        batching: false,
+        timeout: 3600000,
+        basicAuth: config.get("grafana.username")
+          ? `${config.get("grafana.username")}:${config.get("grafana.password")}`
+          : undefined,
+        format: format.combine(
+          format.timestamp(),
+          format.printf(
+            (info) =>
+              `${info.timestamp} | ${info.level.padEnd(5).toUpperCase()} | ${info.message}`,
+          ),
+        ),
+        labels: {
+          app: config.get("appName"),
+          source,
+          level: "debug",
+        },
+        useWinstonMetaAsLabels: true,
+        ignoredMeta: ["level"],
+        metaToUseAsLabels: ["eventName"],
+        onConnectionError: (err) => {
+          console.log("Loki connection error", err);
+          generalLogger.error(`Loki connection error ${err}`);
+        },
+        handleExceptions: true,
+        handleRejections: true,
+      }),
+    new WinstonToSocketTransport({
+      logFn: (info: EventLogNotification) => {
+        mainSocketService.sendEventLogNotification(info);
+      },
+    }),
+  ].filter((e) => !!e);
+  const newLogger = createLogger({
+    transports: transportsList,
+    level: "debug",
+  });
+  loggers[source] = newLogger;
+  return newLogger;
+};
+
 export default generalLogger;
-export { JobLogger, loggers };
+export { eventLog, JobLogger, loggers };

--- a/src/utils/socketUtils.ts
+++ b/src/utils/socketUtils.ts
@@ -1,0 +1,8 @@
+export const forceToArray = (input: string) => {
+  try {
+    const arrayable = JSON.parse(input);
+    return Array.isArray(arrayable) ? arrayable : [arrayable];
+  } catch (err) {
+    return [input];
+  }
+};


### PR DESCRIPTION
**Features :**
- Adding a general event logs logger based on winston, this will log to files && loki if enabled as well send the events over the main socket to subscribed clients
- Adding log events for Job start and end (the only ones at this point)

**Improvements :**
- Refactoring job event handling to aid in setting up the system log events.
- Updating loki logs proxy request to handle merging loki streams if needed, while keeping the stream labels and appending them to each message (might be high on the memory but we'll see) 
