### PR TITLE
[MAIN-IMP] Fix encryption handling and socket service bugs

### DIFF
--- a/src/api/system/config.controller.ts
+++ b/src/api/system/config.controller.ts
@@ -5,6 +5,7 @@ import {
   ObjectifyFlattenedProperties,
   updateMultiConfig,
 } from "@config/config.service";
+import { categorizeConfig } from "@utils/convictUtils";
 import { createElysia } from "@utils/createElysia";
 import qs from "qs";
 
@@ -19,6 +20,10 @@ export const configController = createElysia({ prefix: "/system/config" })
   .get("/getConfig", async () => {
     const config = await getConfigWithDBEncryptionStatus();
     return ObjectifyFlattenedProperties(config);
+  })
+  .get("/getCategorizedConfig", async () => {
+    const config = await getConfigWithDBEncryptionStatus();
+    return categorizeConfig(ObjectifyFlattenedProperties(config));
   })
   .post(
     "/updateConfig",

--- a/src/api/system/config.controller.ts
+++ b/src/api/system/config.controller.ts
@@ -5,7 +5,7 @@ import {
   ObjectifyFlattenedProperties,
   updateMultiConfig,
 } from "@config/config.service";
-import { categorizeConfig } from "@utils/convictUtils";
+import { categorizeConfig, transposedConfigMap } from "@utils/convictUtils";
 import { createElysia } from "@utils/createElysia";
 import qs from "qs";
 
@@ -19,7 +19,10 @@ export const configController = createElysia({ prefix: "/system/config" })
   })
   .get("/getConfig", async () => {
     const config = await getConfigWithDBEncryptionStatus();
-    return ObjectifyFlattenedProperties(config);
+    return {
+      configArray: ObjectifyFlattenedProperties(config),
+      categoriesMap: transposedConfigMap,
+    };
   })
   .get("/getCategorizedConfig", async () => {
     const config = await getConfigWithDBEncryptionStatus();

--- a/src/api/websocket/mainSocket.service.ts
+++ b/src/api/websocket/mainSocket.service.ts
@@ -103,8 +103,8 @@ export default {
     }
   },
   unsubscribeFromTopics(userId: string, topics: string[]) {
-    this.topicsSubscriptions[userId] = this.topicsSubscriptions[userId].filter(
-      (e) => !topics.includes(e),
-    );
+    this.topicsSubscriptions[userId] =
+      this.topicsSubscriptions[userId]?.filter((e) => !topics.includes(e)) ??
+      [];
   },
 };

--- a/src/repositories/configs.ts
+++ b/src/repositories/configs.ts
@@ -1,6 +1,7 @@
 import { basePrisma } from "@initialization/index";
+import { LogEventNames } from "@typesDef/api/jobs";
 import encryptionUtils from "@utils/encryptionUtils";
-
+import logger, { eventLog } from "@utils/loggers";
 export const getAllConfigs = (
   limit?: number,
   offset?: number,
@@ -67,6 +68,14 @@ export const saveConfig = async (
       key: key,
     },
   });
+  if (existingConfig?.is_encrypted !== is_encrypted) {
+    const sysLog = eventLog(LogEventNames.SysLogEvent);
+    const message = `config ${key} has changed encryption status from ${existingConfig?.is_encrypted} to ${is_encrypted}`;
+    sysLog.warn(message, {
+      eventName: "CONFIG_ENCRYPTION_STATUS_CHANGED",
+    });
+    logger.warn(message);
+  }
   const finalValue = is_encrypted
     ? encryptionUtils.encryptWithMasterKey(value)
     : value;
@@ -78,6 +87,7 @@ export const saveConfig = async (
         },
         data: {
           value: finalValue,
+          is_encrypted: is_encrypted ?? existingConfig.is_encrypted,
           appConfigAudit: {
             create: {
               changedBy: {
@@ -85,7 +95,7 @@ export const saveConfig = async (
                   id: userId,
                 },
               },
-              newValue: value,
+              newValue: finalValue,
               oldValue: existingConfig.value,
             },
           },
@@ -108,7 +118,7 @@ export const saveConfig = async (
                         id: userId,
                       },
                     },
-                    newValue: value,
+                    newValue: finalValue,
                     oldValue: null,
                   },
                 },

--- a/src/utils/convictUtils.ts
+++ b/src/utils/convictUtils.ts
@@ -136,3 +136,30 @@ export const toSafeString = (input: any) => {
     return input;
   }
 };
+
+// A human-readable map of config categories, might change to the convict schema if possible
+const categoriesMap: any = {
+  system: ["DB", "baseDB", "env", "appName", "server", "jobs", "swaggerServer"],
+  logging: ["files"],
+  notifications: ["notifications", "grafana"],
+};
+export const categorizeConfig = (inputConfigObject: any) => {
+  const transposedConfigMap = Object.keys(categoriesMap).reduce(
+    (p: any, c: string) => {
+      categoriesMap[c].forEach((e: any) => {
+        p[e] = c;
+      });
+      return p;
+    },
+    {},
+  );
+  return Object.keys(inputConfigObject).reduce((p: any, c: string) => {
+    const categoryName = transposedConfigMap[c] ?? "custom";
+    if (p[categoryName]) {
+      p[categoryName][c] = inputConfigObject[c];
+    } else {
+      p[categoryName] = { [c]: inputConfigObject[c] };
+    }
+    return p;
+  }, {});
+};

--- a/src/utils/convictUtils.ts
+++ b/src/utils/convictUtils.ts
@@ -143,16 +143,18 @@ const categoriesMap: any = {
   logging: ["files"],
   notifications: ["notifications", "grafana"],
 };
+
+const transposedConfigMap = Object.keys(categoriesMap).reduce(
+  (p: any, c: string) => {
+    categoriesMap[c].forEach((e: any) => {
+      p[e] = c;
+    });
+    return p;
+  },
+  {},
+);
+
 export const categorizeConfig = (inputConfigObject: any) => {
-  const transposedConfigMap = Object.keys(categoriesMap).reduce(
-    (p: any, c: string) => {
-      categoriesMap[c].forEach((e: any) => {
-        p[e] = c;
-      });
-      return p;
-    },
-    {},
-  );
   return Object.keys(inputConfigObject).reduce((p: any, c: string) => {
     const categoryName = transposedConfigMap[c] ?? "custom";
     if (p[categoryName]) {

--- a/src/utils/convictUtils.ts
+++ b/src/utils/convictUtils.ts
@@ -144,7 +144,7 @@ const categoriesMap: any = {
   notifications: ["notifications", "grafana"],
 };
 
-const transposedConfigMap = Object.keys(categoriesMap).reduce(
+export const transposedConfigMap = Object.keys(categoriesMap).reduce(
   (p: any, c: string) => {
     categoriesMap[c].forEach((e: any) => {
       p[e] = c;


### PR DESCRIPTION
## **Improvements:**

- [improvement] Added categorized config endpoint and the categorization based on a static map (for now until we can map the category in the`convict` schema)
- [BugFix] Fixed encryption status not being properly saved to config database when updating config
- [BugFix] Fixed encrypted values showing plain in configAudit instead of encrypted values
- [BugFix] Fixed socketService unsubscribe bug where socket tries to unsubscribe from event without subscribing previously

## **Notes**

- [Impact] Encrypted config values do not show as decrypted in the audit table
- 
## **How Has This Been Tested?**

- Manual testing performed for the config and DB

## **Related Issues**

## **Additional Context**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new endpoint to retrieve system configuration organized by categories
  
* **Bug Fixes**
  * Fixed potential error when unsubscribing from WebSocket topics with no active subscriptions

* **Improvements**
  * Enhanced configuration audit logging with encryption status tracking and warnings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->