### PR TITLE
[DEV-IMP] Serving a categorization map with the config endpoint

### DIFF
--- a/src/api/system/config.controller.ts
+++ b/src/api/system/config.controller.ts
@@ -5,7 +5,7 @@ import {
   ObjectifyFlattenedProperties,
   updateMultiConfig,
 } from "@config/config.service";
-import { categorizeConfig } from "@utils/convictUtils";
+import { categorizeConfig, transposedConfigMap } from "@utils/convictUtils";
 import { createElysia } from "@utils/createElysia";
 import qs from "qs";
 
@@ -19,7 +19,10 @@ export const configController = createElysia({ prefix: "/system/config" })
   })
   .get("/getConfig", async () => {
     const config = await getConfigWithDBEncryptionStatus();
-    return ObjectifyFlattenedProperties(config);
+    return {
+      configArray: ObjectifyFlattenedProperties(config),
+      categoriesMap: transposedConfigMap,
+    };
   })
   .get("/getCategorizedConfig", async () => {
     const config = await getConfigWithDBEncryptionStatus();

--- a/src/utils/convictUtils.ts
+++ b/src/utils/convictUtils.ts
@@ -144,7 +144,7 @@ const categoriesMap: any = {
   notifications: ["notifications", "grafana"],
 };
 
-const transposedConfigMap = Object.keys(categoriesMap).reduce(
+export const transposedConfigMap = Object.keys(categoriesMap).reduce(
   (p: any, c: string) => {
     categoriesMap[c].forEach((e: any) => {
       p[e] = c;


### PR DESCRIPTION
### Improvements : 
- Updating the default `/getConfig` endpoint to serve the categorization map alongside the config list. This is to help the frontend handle the configuration categorization and keep the simple handling already implemented

