### PR TITLE
[MAIN-IMP] Add error logging and hide sensitive configs from individual jobs

### DIFF
--- a/src/api/system/config.controller.ts
+++ b/src/api/system/config.controller.ts
@@ -18,14 +18,18 @@ export const configController = createElysia({ prefix: "/system/config" })
     ctx.query = qs.parse(new URL(ctx.request.url).search.slice(1));
   })
   .get("/getConfig", async () => {
-    const config = await getConfigWithDBEncryptionStatus();
+    const config = await getConfigWithDBEncryptionStatus({
+      returnNotificationServiceConfig: false,
+    });
     return {
       configArray: ObjectifyFlattenedProperties(config),
       categoriesMap: transposedConfigMap,
     };
   })
   .get("/getCategorizedConfig", async () => {
-    const config = await getConfigWithDBEncryptionStatus();
+    const config = await getConfigWithDBEncryptionStatus({
+      returnNotificationServiceConfig: false,
+    });
     return categorizeConfig(ObjectifyFlattenedProperties(config));
   })
   .post(

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -68,9 +68,11 @@ const verifyMasterKey = () => {
 export const getConvictSchemaProperties = ({
   encryptedValues = true,
   onlyMirroredValues = true,
+  withJobHiddenProperties = true,
 }: {
   encryptedValues?: boolean;
   onlyMirroredValues?: boolean;
+  withJobHiddenProperties?: boolean;
 } = {}) => {
   const propertiesValues: FlattenedProperties = flattenedProperties(
     config.getProperties(),
@@ -103,6 +105,9 @@ export const getConvictSchemaProperties = ({
       propertiesValues[pvk].value = propertiesValues[pvk].value?.toString();
     }
     if (onlyMirroredValues && !propertiesValues[pvk].db_mirror) {
+      delete propertiesValues[pvk];
+    }
+    if (!withJobHiddenProperties && propertiesValues[pvk].job_hidden) {
       delete propertiesValues[pvk];
     }
   });

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -107,7 +107,11 @@ export const getConvictSchemaProperties = ({
     if (onlyMirroredValues && !propertiesValues[pvk].db_mirror) {
       delete propertiesValues[pvk];
     }
-    if (!withJobHiddenProperties && propertiesValues[pvk].job_hidden) {
+    if (
+      !withJobHiddenProperties &&
+      propertiesValues[pvk] &&
+      propertiesValues[pvk].job_hidden
+    ) {
       delete propertiesValues[pvk];
     }
   });

--- a/src/config/config.service.ts
+++ b/src/config/config.service.ts
@@ -1,6 +1,10 @@
 import config from "@config/config";
 import { deleteConfig, getAllConfigs, saveConfig } from "@repositories/configs";
-import { FlattenedProperties } from "@typesDef/models/config";
+import {
+  FlattenedProperties,
+  getConfigWithDBEncryptionStatusInterface,
+  getConvictSchemaPropertiesInputInterface,
+} from "@typesDef/models/config";
 import { toSafeString } from "@utils/convictUtils";
 import logger from "@utils/loggers";
 
@@ -31,6 +35,7 @@ const flattenedProperties = (inputObj: any) => {
 
 export const ObjectifyFlattenedProperties = (
   flattenedProperties: FlattenedProperties,
+  replacer: (value: FlattenedProperties[string]) => any = (value) => value,
 ) => {
   const parsedCnfs = {} as { [key: string]: any };
   Object.keys(flattenedProperties)
@@ -44,7 +49,7 @@ export const ObjectifyFlattenedProperties = (
       let current = parsedCnfs;
       input.key.forEach((e, i) => {
         if (i === input.key.length - 1) {
-          current[e] = input.value;
+          current[e] = replacer(input.value);
         } else {
           if (!(e in current)) {
             current[e] = {};
@@ -69,11 +74,7 @@ export const getConvictSchemaProperties = ({
   encryptedValues = true,
   onlyMirroredValues = true,
   withJobHiddenProperties = true,
-}: {
-  encryptedValues?: boolean;
-  onlyMirroredValues?: boolean;
-  withJobHiddenProperties?: boolean;
-} = {}) => {
+}: getConvictSchemaPropertiesInputInterface = {}) => {
   const propertiesValues: FlattenedProperties = flattenedProperties(
     config.getProperties(),
   );
@@ -84,6 +85,7 @@ export const getConvictSchemaProperties = ({
       return [e, flattenedSchema[e]];
     }),
   );
+
   // injecting extra properties from schema into property values;
   // TODO see if this can be suggested to convict in a PR
   Object.keys(propertiesValues).forEach((pvk) => {
@@ -96,6 +98,8 @@ export const getConvictSchemaProperties = ({
       schemaValues[`${pvk}_db_mirror`]?.value ?? true; // save to db by default
     propertiesValues[pvk].format =
       schemaValues[`${pvk}_format`]?.value ?? "string"; // save to db by default
+    propertiesValues[pvk].job_hidden =
+      schemaValues[`${pvk}_job_hidden`]?.value ?? false; // hide from jobs, can be different from db_mirror values
     if (schemaValues[`${pvk}_doc`]) {
       propertiesValues[pvk].base = true;
     }
@@ -107,6 +111,7 @@ export const getConvictSchemaProperties = ({
     if (onlyMirroredValues && !propertiesValues[pvk].db_mirror) {
       delete propertiesValues[pvk];
     }
+
     if (
       !withJobHiddenProperties &&
       propertiesValues[pvk] &&
@@ -119,10 +124,13 @@ export const getConvictSchemaProperties = ({
   return propertiesValues;
 };
 
-export const getConfigWithDBEncryptionStatus = async () => {
+export const getConfigWithDBEncryptionStatus = async (
+  SchemaPropertyConfig?: getConfigWithDBEncryptionStatusInterface,
+) => {
   const configList = getConvictSchemaProperties({
     encryptedValues: false,
     onlyMirroredValues: true,
+    ...(SchemaPropertyConfig ?? {}),
   });
   const configFromDB = (await getAllConfigs()).reduce(
     (p, c) => {
@@ -135,13 +143,19 @@ export const getConfigWithDBEncryptionStatus = async () => {
     {} as { [key: string]: { value: any; is_encrypted: boolean } },
   );
   for (const cnfKey in configList) {
-    configList[cnfKey].is_encrypted = configFromDB[cnfKey].is_encrypted;
-    if (configList[cnfKey].is_encrypted) {
-      configList[cnfKey].value = "*******************";
+    if (SchemaPropertyConfig?.onlyMirroredValues || configFromDB[cnfKey]) {
+      configList[cnfKey].is_encrypted = configFromDB[cnfKey].is_encrypted;
+      if (configList[cnfKey].is_encrypted) {
+        configList[cnfKey].value = "*******************";
+      }
     }
-    // deleting Notification configs to force them to be updated on the dedicated UI, might change this in the future
-    // depending on the evolution of the backend
-    if (cnfKey.match(/^notifications_(.+)_(.+)/g)) {
+
+    // deleting Notification configs to force them to be updated on the dedicated UI,
+    // Adding a config param for this since we are using it for the job consumer config
+    if (
+      !SchemaPropertyConfig?.returnNotificationServiceConfig &&
+      cnfKey.match(/^notifications_(.+)_(.+)/g)
+    ) {
       delete configList[cnfKey];
     }
   }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -320,6 +320,7 @@ const config = convict({
       env: "MASTER_ENCRYPTION_KEY",
       sensitive: true,
       db_mirror: false,
+      job_hidden: true,
     },
   },
   version: {

--- a/src/initialization/jobsManager.ts
+++ b/src/initialization/jobsManager.ts
@@ -58,6 +58,13 @@ export const fullStartAJob = async (job: JobDTO) => {
   } else {
     logger.error("Error when starting Job");
     logger.error(d);
+    const sysLog = eventLog(LogEventNames.SysLogEvent);
+    sysLog.error(
+      `Error when starting job ${job.getName()} ${JSON.stringify(d, null, 4)}`,
+      {
+        eventName: "JOB_START_ERROR",
+      },
+    );
     throw d;
   }
 };

--- a/src/initialization/jobsManager.ts
+++ b/src/initialization/jobsManager.ts
@@ -2,7 +2,7 @@ import { JobConsumer } from "@jobConsumer/jobConsumer";
 import { jobEventLog, LogEventNames } from "@typesDef/api/jobs";
 import { JobDTO, jobStatus } from "@typesDef/models/job";
 import currentRunsManager from "@utils/CurrentRunsManager";
-import { toJSON } from "@utils/jobUtils";
+import { getCircularReplacer } from "@utils/jobUtils";
 import logger, { eventLog, JobLogger } from "@utils/loggers";
 import schedulerManager from "schedule-manager";
 const { ScheduleJobEventBus, ScheduleJobLogEventBus, ScheduleJobManager } =
@@ -60,9 +60,12 @@ export const fullStartAJob = async (job: JobDTO) => {
     logger.error("Error when starting Job");
     logger.error(d);
     const sysLog = eventLog(LogEventNames.SysLogEvent);
-    sysLog.error(`Error when starting job ${job.getName()} ${toJSON(d, 4)}`, {
-      eventName: "JOB_START_ERROR",
-    });
+    sysLog.error(
+      `Error when starting job ${job.getName()} ${JSON.stringify(d, getCircularReplacer(), 4)}`,
+      {
+        eventName: "JOB_START_ERROR",
+      },
+    );
     throw d;
   }
 };

--- a/src/initialization/jobsManager.ts
+++ b/src/initialization/jobsManager.ts
@@ -2,6 +2,7 @@ import { JobConsumer } from "@jobConsumer/jobConsumer";
 import { jobEventLog, LogEventNames } from "@typesDef/api/jobs";
 import { JobDTO, jobStatus } from "@typesDef/models/job";
 import currentRunsManager from "@utils/CurrentRunsManager";
+import { toJSON } from "@utils/jobUtils";
 import logger, { eventLog, JobLogger } from "@utils/loggers";
 import schedulerManager from "schedule-manager";
 const { ScheduleJobEventBus, ScheduleJobLogEventBus, ScheduleJobManager } =
@@ -59,12 +60,9 @@ export const fullStartAJob = async (job: JobDTO) => {
     logger.error("Error when starting Job");
     logger.error(d);
     const sysLog = eventLog(LogEventNames.SysLogEvent);
-    sysLog.error(
-      `Error when starting job ${job.getName()} ${JSON.stringify(d, null, 4)}`,
-      {
-        eventName: "JOB_START_ERROR",
-      },
-    );
+    sysLog.error(`Error when starting job ${job.getName()} ${toJSON(d, 4)}`, {
+      eventName: "JOB_START_ERROR",
+    });
     throw d;
   }
 };

--- a/src/jobConsumer/jobConsumer.ts
+++ b/src/jobConsumer/jobConsumer.ts
@@ -1,6 +1,6 @@
 import config from "@config/config";
 import {
-  getConvictSchemaProperties,
+  getConfigWithDBEncryptionStatus,
   ObjectifyFlattenedProperties,
 } from "@config/config.service";
 import { handleEvent } from "@repositories/notification";
@@ -245,10 +245,13 @@ export class JobConsumer extends Consumer {
       this.options = {
         utils: jobConsumerUtils,
         config: ObjectifyFlattenedProperties(
-          getConvictSchemaProperties({
+          await getConfigWithDBEncryptionStatus({
             encryptedValues: false,
             withJobHiddenProperties: false,
+            onlyMirroredValues: false,
+            returnNotificationServiceConfig: true,
           }),
+          (v) => v?.value ?? v,
         ),
       };
       await this.injectNotificationServices(

--- a/src/jobConsumer/jobConsumer.ts
+++ b/src/jobConsumer/jobConsumer.ts
@@ -1,4 +1,8 @@
 import config from "@config/config";
+import {
+  getConvictSchemaProperties,
+  ObjectifyFlattenedProperties,
+} from "@config/config.service";
 import { handleEvent } from "@repositories/notification";
 import {
   getAllGlobalEventHandlers,
@@ -240,7 +244,12 @@ export class JobConsumer extends Consumer {
     try {
       this.options = {
         utils: jobConsumerUtils,
-        config: config.getProperties(),
+        config: ObjectifyFlattenedProperties(
+          getConvictSchemaProperties({
+            encryptedValues: false,
+            withJobHiddenProperties: false,
+          }),
+        ),
       };
       await this.injectNotificationServices(
         job?.param?.notificationServices || [],

--- a/src/jobs/testJob.ts
+++ b/src/jobs/testJob.ts
@@ -11,6 +11,7 @@ class TestJob extends JobConsumer {
     this.logEvent("will sleep");
     this.emitError("testing error");
     this.emitWarning("texting warning");
+    this.logEvent(this.options?.config);
     await this.options?.utils?.sleep(15);
     this.logEvent("finished sleeping");
     await this.exportResultsToFile({

--- a/src/types/models/config.ts
+++ b/src/types/models/config.ts
@@ -10,3 +10,14 @@ export interface FlattenedProperties {
     base?: boolean;
   };
 }
+
+export interface getConvictSchemaPropertiesInputInterface {
+  encryptedValues?: boolean;
+  onlyMirroredValues?: boolean;
+  withJobHiddenProperties?: boolean;
+}
+
+export interface getConfigWithDBEncryptionStatusInterface
+  extends getConvictSchemaPropertiesInputInterface {
+  returnNotificationServiceConfig?: boolean;
+}

--- a/src/types/models/config.ts
+++ b/src/types/models/config.ts
@@ -3,6 +3,7 @@ export interface FlattenedProperties {
     value: any;
     is_encrypted?: boolean;
     db_mirror?: boolean;
+    job_hidden?: boolean;
     doc?: string;
     default?: string;
     format?: string;

--- a/src/utils/convictUtils.ts
+++ b/src/utils/convictUtils.ts
@@ -139,7 +139,16 @@ export const toSafeString = (input: any) => {
 
 // A human-readable map of config categories, might change to the convict schema if possible
 const categoriesMap: any = {
-  system: ["DB", "baseDB", "env", "appName", "server", "jobs", "swaggerServer"],
+  system: [
+    "DB",
+    "baseDB",
+    "env",
+    "appName",
+    "server",
+    "jobs",
+    "swaggerServer",
+    "proxies",
+  ],
   logging: ["files"],
   notifications: ["notifications", "grafana"],
 };

--- a/src/utils/jobUtils.ts
+++ b/src/utils/jobUtils.ts
@@ -165,14 +165,26 @@ export const getFromCache = async (fileName: string) => {
  * @param param  A jsonifiable object
  * @returns string
  */
-export const toJSON = (param: any, space?: number): any => {
+export const toJSON = (param: any): any => {
   return JSON.parse(
     JSON.stringify(
       param,
       (key, value) => (typeof value === "bigint" ? value.toString() : value), // return everything else unchanged
-      space,
     ),
   );
+};
+
+export const getCircularReplacer = () => {
+  const seen = new WeakSet();
+  return (key: any, value: any) => {
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) {
+        return "[Circular]";
+      }
+      seen.add(value);
+    }
+    return value;
+  };
 };
 
 /**

--- a/src/utils/jobUtils.ts
+++ b/src/utils/jobUtils.ts
@@ -165,11 +165,12 @@ export const getFromCache = async (fileName: string) => {
  * @param param  A jsonifiable object
  * @returns string
  */
-export const toJSON = (param: any): any => {
+export const toJSON = (param: any, space?: number): any => {
   return JSON.parse(
     JSON.stringify(
       param,
       (key, value) => (typeof value === "bigint" ? value.toString() : value), // return everything else unchanged
+      space,
     ),
   );
 };


### PR DESCRIPTION
## **Improvements:**
- Error handling] : Added sysLog error logging when job initialization fails to improve debugging visibility
- [security] : Introduced job_hidden property to use when passing configuration to jobs, without the sensitive data being decrypted
- [refactoring] : Added proxies to system categories map for better config organization
- [logging] : Added sysLog event logging for job startup failures with structured JSON output
- [code quality] : Fixed config item access after deletion bug when converting schema to job-accessible version
- [security] : Added job_hidden schema property to hide sensitive config values (like MASTER_ENCRYPTION_KEY) from job contexts
- [refactoring] : Config API will explicitly not return the notification services configs 

## **Notes**

- [Note] (testing) : testJob.ts was updated to log config object for verification purposes during development

## **How Has This Been Tested?**

- Manual testing performed with job startup failures
- Verified config properties correctly hidden in job context

## **Related Issues**

## **Screenshots (if applicable)**

## **Additional Context**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Configuration properties can now be excluded from job contexts based on job visibility settings.
  * Improved error logging for job startup failures with detailed diagnostic information.

* **Improvements**
  * Configuration API endpoints now exclude notification service data from responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/moda20/TypeSchedulerBackend/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->