### PR TITLE
[MAIN-Feat] Add proxy manager to job consumer

### DIFF
--- a/src/jobConsumer/jobConsumer.ts
+++ b/src/jobConsumer/jobConsumer.ts
@@ -224,6 +224,7 @@ export class JobConsumer extends Consumer {
     // and assign proxies ot it using the general manager.
 
     // if there is case where there is an existing proxyManager in this instance, the previous one will have it's axios interceptors
+    // cleared
     if (this.proxyManager) {
       this.proxyManager.clearInterceptors();
     }

--- a/src/jobConsumer/jobConsumer.ts
+++ b/src/jobConsumer/jobConsumer.ts
@@ -30,7 +30,7 @@ import {
   getFromCache,
   injectNotificationServices,
 } from "@utils/jobUtils";
-import { injectProxy } from "@utils/proxyUtils";
+import { injectProxy, ProxyManager } from "@utils/proxyUtils";
 import type { AxiosInstance } from "axios";
 import scheduleManager, {
   IScheduleJob,
@@ -48,6 +48,7 @@ export class JobConsumer extends Consumer {
   eventHandlers: Partial<{
     [key in JobNotificationTypesType]: JobEventHandlerConfig[];
   }> = {};
+  proxyManager?: ProxyManager;
   constructor() {
     super();
     this.axios = defaultAxiosInstance.create();
@@ -238,7 +239,15 @@ export class JobConsumer extends Consumer {
     this.job = job;
     this.jobLog = jobLog;
     const proxyConfig = job.param?.proxyConfig;
-    await this.injectProxies(proxyConfig);
+    this.proxyManager = new ProxyManager({
+      jobId: job.id!,
+      defaultAxiosInstance: this.axios,
+      proxyStrategy: proxyConfig?.proxyStrategy,
+      targetProxyId: proxyConfig?.targetProxyId,
+      logger: (v) => this.logEvent(v),
+    });
+    await this.proxyManager.injectProxies();
+
     // initializing the notification service to work with the new structure of services
     await this.initializeNotificationService(job, jobLog);
     try {

--- a/src/jobConsumer/jobConsumer.ts
+++ b/src/jobConsumer/jobConsumer.ts
@@ -21,7 +21,6 @@ import {
   jobNotificationTypes,
   JobNotificationTypesType,
 } from "@typesDef/notifications";
-import { jobProxyConfig } from "@typesDef/proxies";
 import defaultAxiosInstance from "@utils/httpRequestConfig";
 import * as jobConsumerUtils from "@utils/jobConsumerUtils";
 import {
@@ -30,7 +29,7 @@ import {
   getFromCache,
   injectNotificationServices,
 } from "@utils/jobUtils";
-import { injectProxy, ProxyManager } from "@utils/proxyUtils";
+import { ProxyManager } from "@utils/proxyUtils";
 import type { AxiosInstance } from "axios";
 import scheduleManager, {
   IScheduleJob,
@@ -91,27 +90,6 @@ export class JobConsumer extends Consumer {
       targetNotificationService,
       serviceConfig,
     );
-  }
-
-  async injectProxies(proxyConfig?: jobProxyConfig) {
-    return injectProxy({
-      jobId: Number(this.job?.id),
-      axiosInstance: this.axios,
-      logger: (v: any) => this.logEvent(v),
-      proxyStrategy: proxyConfig?.proxyStrategy,
-      targetProxyId: proxyConfig?.targetProxyId,
-    })
-      .then((proxy) => {
-        if (proxy) {
-          this.logEvent(`proxy ${proxy.proxy_ip}:${proxy.proxy_port} injected`);
-        } else {
-          this.logEvent("no proxy to inject found");
-        }
-      })
-      .catch((err) => {
-        this.logEvent("error injecting proxies");
-        this.logEvent(err);
-      });
   }
   async injectNotificationServices(services: number[]) {
     this.notificationServices = await injectNotificationServices(
@@ -239,6 +217,16 @@ export class JobConsumer extends Consumer {
     this.job = job;
     this.jobLog = jobLog;
     const proxyConfig = job.param?.proxyConfig;
+    // Setting the object proxyManager to a new manager for each run, can cause issues for overlapping cron based runs
+    // when proxies change between the execution time (based on random or least X strategy, or if the proxies linked change)
+    // This is due to the fact that for cron based runs we use a singular instance of the consumer.
+    // IF this can create issues for your consumer scripts, it's better to use a new axios instance that you control in your own code
+    // and assign proxies ot it using the general manager.
+
+    // if there is case where there is an existing proxyManager in this instance, the previous one will have it's axios interceptors
+    if (this.proxyManager) {
+      this.proxyManager.clearInterceptors();
+    }
     this.proxyManager = new ProxyManager({
       jobId: job.id!,
       defaultAxiosInstance: this.axios,
@@ -246,7 +234,10 @@ export class JobConsumer extends Consumer {
       targetProxyId: proxyConfig?.targetProxyId,
       logger: (v) => this.logEvent(v),
     });
-    await this.proxyManager.injectProxies();
+    await this.proxyManager.injectProxies().catch((err) => {
+      this.logEvent("error injecting proxies, proceeding without proxies");
+      this.logEvent(err);
+    });
 
     // initializing the notification service to work with the new structure of services
     await this.initializeNotificationService(job, jobLog);

--- a/src/types/models/job.ts
+++ b/src/types/models/job.ts
@@ -1,6 +1,7 @@
 import config from "@config/config";
 import { schedule_job } from "@generated/prisma";
 import * as JobConsumerUtils from "@utils/jobConsumerUtils";
+import { ProxyManager } from "@utils/proxyUtils";
 import { IScheduleJob, IScheduleJobLog } from "schedule-manager";
 import { ScheduleJobLog } from "schedule-manager/Classes/Entities/ScheduleJobLog";
 import { ScheduleJobTable } from "schedule-manager/dist/Classes/Entities/ScheduleJob";

--- a/src/types/models/job.ts
+++ b/src/types/models/job.ts
@@ -1,7 +1,5 @@
-import config from "@config/config";
 import { schedule_job } from "@generated/prisma";
 import * as JobConsumerUtils from "@utils/jobConsumerUtils";
-import { ProxyManager } from "@utils/proxyUtils";
 import { IScheduleJob, IScheduleJobLog } from "schedule-manager";
 import { ScheduleJobLog } from "schedule-manager/Classes/Entities/ScheduleJobLog";
 import { ScheduleJobTable } from "schedule-manager/dist/Classes/Entities/ScheduleJob";

--- a/src/types/proxies.ts
+++ b/src/types/proxies.ts
@@ -17,5 +17,5 @@ export interface ProxyManagerConstructorInterface {
   defaultAxiosInstance: AxiosInstance;
   proxyStrategy?: proxyPickingStrategy;
   targetProxyId?: number;
-  logger?: (data: any) => void;
+  logger: (data: any) => void;
 }

--- a/src/types/proxies.ts
+++ b/src/types/proxies.ts
@@ -1,3 +1,5 @@
+import type { AxiosInstance } from "axios";
+
 export enum proxyPickingStrategy {
   RANDOM = "RANDOM",
   ROUND_ROBIN = "ROUND_ROBIN",
@@ -8,4 +10,12 @@ export enum proxyPickingStrategy {
 export interface jobProxyConfig {
   proxyStrategy?: proxyPickingStrategy;
   targetProxyId?: number;
+}
+
+export interface ProxyManagerConstructorInterface {
+  jobId: number;
+  defaultAxiosInstance: AxiosInstance;
+  proxyStrategy?: proxyPickingStrategy;
+  targetProxyId?: number;
+  logger?: (data: any) => void;
 }

--- a/src/utils/proxyUtils.ts
+++ b/src/utils/proxyUtils.ts
@@ -5,7 +5,11 @@ import {
   incrementProxyUsage,
 } from "@repositories/proxies";
 import { LogEventNames } from "@typesDef/api/jobs";
-import { proxyPickingStrategy } from "@typesDef/proxies";
+import {
+  ProxyManagerConstructorInterface,
+  proxyPickingStrategy,
+} from "@typesDef/proxies";
+import defaultAxiosInstance from "@utils/httpRequestConfig";
 import { eventLog } from "@utils/loggers";
 import type { AxiosInstance } from "axios";
 import { fetch as bunFetch } from "netbun";
@@ -123,9 +127,73 @@ export const injectProxy = async ({
       };
     } else {
       logger &&
-        logger.warn(
-          `No proxy was picked based on strategy : ${proxyPickingStrategy}`,
-        );
+        logger.warn(`No proxy was picked based on strategy : ${proxyStrategy}`);
     }
   }
 };
+
+export class ProxyManager {
+  jobId: number;
+  defaultAxiosInstance: AxiosInstance;
+  proxyStrategy?: proxyPickingStrategy;
+  targetProxyId?: number;
+  logger?: (data: any) => void;
+  constructor({
+    defaultAxiosInstance,
+    logger,
+    proxyStrategy,
+    targetProxyId,
+    jobId,
+  }: ProxyManagerConstructorInterface) {
+    this.jobId = jobId;
+    this.defaultAxiosInstance = defaultAxiosInstance;
+    this.proxyStrategy = proxyStrategy;
+    this.targetProxyId = targetProxyId;
+    this.logger = logger;
+  }
+
+  async injectProxies() {
+    return injectProxy({
+      jobId: this.jobId,
+      axiosInstance: this.defaultAxiosInstance,
+      logger: this.logger,
+      proxyStrategy: this.proxyStrategy,
+      targetProxyId: this.targetProxyId,
+    });
+  }
+
+  async reInjectProxies(
+    newStrategy?: proxyPickingStrategy,
+    newProxyTargetId?: number,
+  ) {
+    return injectProxy({
+      jobId: this.jobId,
+      axiosInstance: this.defaultAxiosInstance,
+      logger: this.logger,
+      proxyStrategy: newStrategy ?? this.proxyStrategy,
+      targetProxyId: newProxyTargetId ?? this.targetProxyId,
+    });
+  }
+
+  async injectProxiesIntoANewClient(
+    targetInstance?: AxiosInstance,
+    proxyStrategy?: proxyPickingStrategy,
+    newProxyTargetId?: number,
+  ) {
+    const newInstance = targetInstance ?? defaultAxiosInstance.create();
+    await injectProxy({
+      jobId: this.jobId,
+      axiosInstance: newInstance,
+      logger: this.logger,
+      proxyStrategy: proxyStrategy ?? this.proxyStrategy,
+      targetProxyId: newProxyTargetId ?? this.targetProxyId,
+    });
+    return newInstance;
+  }
+
+  async uninjectProxies(targetInstance: AxiosInstance) {
+    delete targetInstance.defaults.env?.fetch;
+    delete targetInstance.defaults.proxy;
+    return targetInstance;
+  }
+}

--- a/src/utils/proxyUtils.ts
+++ b/src/utils/proxyUtils.ts
@@ -26,7 +26,7 @@ export const injectProxyIntoInstance = (
         "!!WARNING!! Using socks proxy will use a custom fetch function. Check here : https://github.com/oven-sh/bun/issues/16812",
       );
     const proxyUrl = `${proxy.protocol}://${proxy.username ? proxy.username + ":" + proxy.password + "@" : ""}${proxy.proxy_ip}:${proxy.proxy_port}`;
-    // TODO as of this addition, bun doesn't fully oir partially support socks5 proxies,
+    // TODO as of this addition, bun doesn't fully or partially support socks5 proxies,
     // so we are going to use a custom fetch function to handle the socks for now.
     // socks proxy is inadvised for now, as this might expose more problems in the future
     axiosInstance.defaults.adapter = "fetch";
@@ -137,7 +137,9 @@ export class ProxyManager {
   defaultAxiosInstance: AxiosInstance;
   proxyStrategy?: proxyPickingStrategy;
   targetProxyId?: number;
-  logger?: (data: any) => void;
+  logger: (data: any) => void = console.log;
+  // a map between the axios instance and a single interceptor id.
+  instanceMap: Map<AxiosInstance, number> = new Map();
   constructor({
     defaultAxiosInstance,
     logger,
@@ -152,8 +154,19 @@ export class ProxyManager {
     this.logger = logger;
   }
 
+  private async injectAndSaveProxies(args: Parameters<typeof injectProxy>[0]) {
+    const injectionResult = await injectProxy(args);
+    if (injectionResult?.proxyUsageInterceptor !== undefined) {
+      this.instanceMap.set(
+        args.axiosInstance,
+        injectionResult.proxyUsageInterceptor,
+      );
+    }
+    return injectionResult;
+  }
+
   async injectProxies() {
-    return injectProxy({
+    return this.injectAndSaveProxies({
       jobId: this.jobId,
       axiosInstance: this.defaultAxiosInstance,
       logger: this.logger,
@@ -166,7 +179,8 @@ export class ProxyManager {
     newStrategy?: proxyPickingStrategy,
     newProxyTargetId?: number,
   ) {
-    return injectProxy({
+    this.uninjectProxies(this.defaultAxiosInstance);
+    return this.injectAndSaveProxies({
       jobId: this.jobId,
       axiosInstance: this.defaultAxiosInstance,
       logger: this.logger,
@@ -181,7 +195,8 @@ export class ProxyManager {
     newProxyTargetId?: number,
   ) {
     const newInstance = targetInstance ?? defaultAxiosInstance.create();
-    await injectProxy({
+    this.uninjectProxies(newInstance);
+    await this.injectAndSaveProxies({
       jobId: this.jobId,
       axiosInstance: newInstance,
       logger: this.logger,
@@ -191,9 +206,31 @@ export class ProxyManager {
     return newInstance;
   }
 
-  async uninjectProxies(targetInstance: AxiosInstance) {
+  uninjectProxies(targetInstance: AxiosInstance) {
     delete targetInstance.defaults.env?.fetch;
     delete targetInstance.defaults.proxy;
+    if (this.instanceMap.has(targetInstance)) {
+      const interceptorId = this.instanceMap.get(targetInstance);
+      if (!interceptorId) {
+        this.logger(
+          "A proxy interceptor id was not found, even though the it was registered",
+        );
+        return;
+      }
+      targetInstance.interceptors.request.eject(interceptorId);
+    }
     return targetInstance;
+  }
+
+  /**
+   * Clears all interceptors from the instance map
+   * This will not clear the injection count, only the usage count interceptors.
+   * Use only if you want to destroy axios references to garbage collect the proxy manager.
+   */
+  clearInterceptors() {
+    for (const [instance, id] of this.instanceMap.entries()) {
+      instance.interceptors.request.eject(id);
+      this.instanceMap.delete(instance);
+    }
   }
 }

--- a/src/utils/proxyUtils.ts
+++ b/src/utils/proxyUtils.ts
@@ -211,13 +211,14 @@ export class ProxyManager {
     delete targetInstance.defaults.proxy;
     if (this.instanceMap.has(targetInstance)) {
       const interceptorId = this.instanceMap.get(targetInstance);
-      if (!interceptorId) {
+      if (interceptorId === undefined) {
         this.logger(
           "A proxy interceptor id was not found, even though the it was registered",
         );
         return;
       }
       targetInstance.interceptors.request.eject(interceptorId);
+      this.instanceMap.delete(targetInstance);
     }
     return targetInstance;
   }


### PR DESCRIPTION
## **features:**

- Added ProxyManager class to encapsulate proxy management logic in jobs
- Migrated injectProxies() method to the new proxy manager (breaking)
- Implemented reInjectProxies() method to re-inject proxies with new strategy or target
- Implemented injectProxiesIntoANewClient() method to inject proxies into a new Axios instance
- Implemented uninjectProxies() method to remove proxy configuration from Axios instances

## **Notes**

None

## **Motivation and Context**

The ProxyManager was added to better handle proxies when writing jobs. the proxy manager will, in the future, handle getting logs, emitting events related to proxies/networking, and proxy metrics. 

The proxy manager also allows creating new clients with new proxy strategies outside the default `jobParams`  supplied one. 

## **How Has This Been Tested?**


## **Screenshots (if applicable)**


## **Types of changes**

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## **Related Issues**

## **Additional Context**



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized proxy injection mechanism to use a dedicated manager instance, improving code structure and maintainability. Proxy functionality remains unchanged from a user perspective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->