### PR TITLE
[DEV-IMP] Add endpoints to get and set proxies directly on a job

### DIFF
--- a/prisma/migrations/20260614170009_adding_uniqueness_constraint_to_proxy_job/migration.sql
+++ b/prisma/migrations/20260614170009_adding_uniqueness_constraint_to_proxy_job/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[job_id,proxy_id]` on the table `proxy_job` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX `proxy_job_job_id_proxy_id_key` ON `proxy_job`(`job_id`, `proxy_id`);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,7 @@ model proxy_job {
 
   @@index([job_id], map: "job_id")
   @@index([proxy_id], map: "proxy_id")
+  @@unique([job_id, proxy_id])
 }
 
 model schedule_job {

--- a/src/api/proxies/proxies.controller.ts
+++ b/src/api/proxies/proxies.controller.ts
@@ -2,10 +2,12 @@ import { t } from "elysia";
 
 import { proxy_status } from "@generated/prisma";
 import {
+  addProxiesToJob,
   addProxy,
   addProxyToJob,
   deleteProxy,
   getAllProxies,
+  getJobProxies,
   getProxy,
   removeProxyFromJob,
   testProxyViaTheAPI,
@@ -51,6 +53,18 @@ export const proxiesController = createElysia({ prefix: "/proxies" })
       }),
     },
   )
+  .get("/getJobProxies", ({ query }) => {
+    return getJobProxies(Number(query.jobId ?? 0)).then((data) => {
+      return data?.proxies?.map((e) => {
+        return {
+          id: e.id,
+          proxy_id: e.proxy_id,
+          proxy_ip: e.proxy.proxy_ip,
+          proxy_port: e.proxy.proxy_port,
+        };
+      });
+    });
+  })
   .post(
     "/addProxy",
     ({ body }) => {
@@ -115,6 +129,18 @@ export const proxiesController = createElysia({ prefix: "/proxies" })
       body: t.Object({
         id: t.Number(),
         job_ids: t.Array(t.Number()),
+      }),
+    },
+  )
+  .post(
+    "/addProxiesToJob",
+    ({ body }) => {
+      return addProxiesToJob(Number(body.job_id ?? 0), body.proxy_ids);
+    },
+    {
+      body: z.object({
+        job_id: z.coerce.number(),
+        proxy_ids: z.array(z.coerce.number().positive()),
       }),
     },
   )

--- a/src/api/proxies/proxies.controller.ts
+++ b/src/api/proxies/proxies.controller.ts
@@ -53,18 +53,26 @@ export const proxiesController = createElysia({ prefix: "/proxies" })
       }),
     },
   )
-  .get("/getJobProxies", ({ query }) => {
-    return getJobProxies(Number(query.jobId ?? 0)).then((data) => {
-      return data?.proxies?.map((e) => {
-        return {
-          id: e.id,
-          proxy_id: e.proxy_id,
-          proxy_ip: e.proxy.proxy_ip,
-          proxy_port: e.proxy.proxy_port,
-        };
+  .get(
+    "/getJobProxies",
+    ({ query }) => {
+      return getJobProxies(query.jobId).then((data) => {
+        return data?.proxies?.map((e) => {
+          return {
+            id: e.id,
+            proxy_id: e.proxy_id,
+            proxy_ip: e.proxy.proxy_ip,
+            proxy_port: e.proxy.proxy_port,
+          };
+        });
       });
-    });
-  })
+    },
+    {
+      query: z.object({
+        jobId: z.coerce.number(),
+      }),
+    },
+  )
   .post(
     "/addProxy",
     ({ body }) => {
@@ -139,7 +147,7 @@ export const proxiesController = createElysia({ prefix: "/proxies" })
     },
     {
       body: z.object({
-        job_id: z.coerce.number(),
+        job_id: z.coerce.number().positive(),
         proxy_ids: z.array(z.coerce.number().positive()),
       }),
     },

--- a/src/repositories/proxies.ts
+++ b/src/repositories/proxies.ts
@@ -190,6 +190,39 @@ export const addProxyToJob = async (id: number, job_ids: number[]) => {
   });
 };
 
+export const addProxiesToJob = async (jobId: number, proxyIds: number[]) => {
+  const existingJobIdLinks = await prisma.proxy_job.findMany({
+    where: {
+      job_id: jobId,
+    },
+  });
+
+  const linksToDelete = existingJobIdLinks.filter(
+    (e) => !proxyIds.includes(e.proxy_id),
+  );
+  const linksToCreate = proxyIds.filter(
+    (e) => !existingJobIdLinks.map((e) => e.proxy_id).includes(e),
+  );
+
+  return prisma.$transaction(async (tx) => {
+    await tx.proxy_job.createMany({
+      data: linksToCreate.map((proxyId) => ({
+        proxy_id: proxyId,
+        job_id: jobId,
+      })),
+    });
+
+    await tx.proxy_job.deleteMany({
+      where: {
+        job_id: jobId,
+        proxy_id: {
+          in: linksToDelete.map((e) => e.proxy_id),
+        },
+      },
+    });
+  });
+};
+
 export const incrementProxyInjection = (proxyJobId: number) => {
   return prisma.proxy_job.update({
     where: {


### PR DESCRIPTION
## **Improvements:**

- [Improvement] : Added GET `/getJobProxies`  and `/addProxiesToJob` endpoints to retrieve all Job linked proxies and save the links with links diff only prisma transaction  

## **Notes**

any notes, opinions, mention, impact :

- [Note] : This allows to add  proxies to a single job instead of only the other way around

## **How Has This Been Tested?**


## **Related Issues**


## **Screenshots (if applicable)**


## **Additional Context**